### PR TITLE
Need to gracefully handle 404

### DIFF
--- a/pureport/data_source_accounts.go
+++ b/pureport/data_source_accounts.go
@@ -67,7 +67,14 @@ func dataSourceAccountsRead(d *schema.ResourceData, m interface{}) error {
 	}
 
 	if resp.StatusCode >= 300 {
+
 		d.SetId("")
+
+		if resp.StatusCode == 404 {
+			// Need to gracefully handle 404, for refresh
+			return nil
+		}
+
 		return fmt.Errorf("Error Response while Reading Pureport Account data")
 	}
 

--- a/pureport/data_source_cloud_regions.go
+++ b/pureport/data_source_cloud_regions.go
@@ -67,6 +67,11 @@ func dataSourceCloudRegionsRead(d *schema.ResourceData, m interface{}) error {
 
 	if resp.StatusCode >= 300 {
 		d.SetId("")
+
+		if resp.StatusCode == 404 {
+			// Need to gracefully handle 404, for refresh
+			return nil
+		}
 		return fmt.Errorf("Error Response while Reading Cloud Region data")
 	}
 

--- a/pureport/data_source_locations.go
+++ b/pureport/data_source_locations.go
@@ -80,6 +80,11 @@ func dataSourceLocationsRead(d *schema.ResourceData, m interface{}) error {
 
 	if resp.StatusCode >= 300 {
 		d.SetId("")
+
+		if resp.StatusCode == 404 {
+			// Need to gracefully handle 404, for refresh
+			return nil
+		}
 		return fmt.Errorf("Error Response while Reading Pureport Location data")
 	}
 

--- a/pureport/data_source_networks.go
+++ b/pureport/data_source_networks.go
@@ -77,6 +77,11 @@ func dataSourceNetworksRead(d *schema.ResourceData, m interface{}) error {
 
 	if resp.StatusCode >= 300 {
 		d.SetId("")
+
+		if resp.StatusCode == 404 {
+			// Need to gracefully handle 404, for refresh
+			return nil
+		}
 		return fmt.Errorf("Error Response while Reading Pureport Network data")
 	}
 

--- a/pureport/resource_aws_connection.go
+++ b/pureport/resource_aws_connection.go
@@ -174,6 +174,7 @@ func resourceAWSConnectionRead(d *schema.ResourceData, m interface{}) error {
 		if resp.StatusCode == 404 {
 			log.Printf("Error Response while reading %s: code=%v", awsConnectionName, resp.StatusCode)
 			d.SetId("")
+			return nil
 		}
 		return fmt.Errorf("Error reading data for %s: %s", awsConnectionName, err)
 	}

--- a/pureport/resource_azure_connection.go
+++ b/pureport/resource_azure_connection.go
@@ -166,6 +166,7 @@ func resourceAzureConnectionRead(d *schema.ResourceData, m interface{}) error {
 		if resp.StatusCode == 404 {
 			log.Printf("Error Response while reading %s: code=%v", azureConnectionName, resp.StatusCode)
 			d.SetId("")
+			return nil
 		}
 		return fmt.Errorf("Error reading data for %s: %s", azureConnectionName, err)
 	}

--- a/pureport/resource_dummy_connection.go
+++ b/pureport/resource_dummy_connection.go
@@ -153,6 +153,7 @@ func resourceDummyConnectionRead(d *schema.ResourceData, m interface{}) error {
 		if resp.StatusCode == 404 {
 			log.Printf("Error Response while reading %s: code=%v", dummyConnectionName, resp.StatusCode)
 			d.SetId("")
+			return nil
 		}
 		return fmt.Errorf("Error reading data for %s: %s", dummyConnectionName, err)
 	}

--- a/pureport/resource_google_cloud_connection.go
+++ b/pureport/resource_google_cloud_connection.go
@@ -163,6 +163,7 @@ func resourceGoogleCloudConnectionRead(d *schema.ResourceData, m interface{}) er
 		if resp.StatusCode == 404 {
 			log.Printf("Error Response while reading %s: code=%v", googleConnectionName, resp.StatusCode)
 			d.SetId("")
+			return nil
 		}
 		return fmt.Errorf("Error reading data for %s: %s", googleConnectionName, err)
 	}

--- a/pureport/resource_network.go
+++ b/pureport/resource_network.go
@@ -139,6 +139,7 @@ func resourceNetworkRead(d *schema.ResourceData, m interface{}) error {
 		if resp.StatusCode == 404 {
 			log.Printf("Error Response while reading Network: code=%v", resp.StatusCode)
 			d.SetId("")
+			return nil
 		}
 		return fmt.Errorf("Error reading data for Network: %s", err)
 	}

--- a/pureport/resource_site_vpn_connection.go
+++ b/pureport/resource_site_vpn_connection.go
@@ -406,6 +406,7 @@ func resourceSiteVPNConnectionRead(d *schema.ResourceData, m interface{}) error 
 		if resp.StatusCode == 404 {
 			log.Printf("Error Response while reading %s: code=%v", sitevpnConnectionName, resp.StatusCode)
 			d.SetId("")
+			return nil
 		}
 		return fmt.Errorf("Error reading data for %s: %s", sitevpnConnectionName, err)
 	}


### PR DESCRIPTION
If we get a 404 when attempting to read a resource, we need to just
indicate that the resource was deleted by setting the ID to empty
and just return without an error. This is so that terraform can refresh
it's state if the resource has been delete from the provider.