### PR TITLE
Increase the deadline since we are using less memory

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -23,5 +23,5 @@ linters-settings:
     ignore: github.com/hashicorp/terraform/helper/schema:ForceNew|Set,fmt:.*,io:Close
 
 run:
-  deadline: 5m
+  deadline: 10m
   modules-download-mode: vendor

--- a/GNUmakefile
+++ b/GNUmakefile
@@ -8,7 +8,6 @@ PROVIDER_VERSION?=dev
 GOOS?=darwin
 GOARCH?=amd64
 GOLINT_GOGC=5
-GOLINT_JOBS=5
 
 default: build
 
@@ -57,7 +56,7 @@ errcheck:
 
 lint:
 	@echo "==> Checking source code against linters..."
-	@GOGC=$(GOLINT_GOGC) golangci-lint run --concurrency $(GOLINT_JOBS) --deadline 4m ./$(PKG_NAME)
+	@GOGC=$(GOLINT_GOGC) golangci-lint run ./$(PKG_NAME)
 	@tfproviderlint -c 1 -S001 -S002 -S003 -S004 -S005 ./$(PKG_NAME)
 
 tools:


### PR DESCRIPTION
Also use the default number of jobs, which should equal the number
of available cores.