### PR TITLE
Allow traffic selectors between 8 and 32 prefix length, rather than between 16 and 32.

### DIFF
--- a/pureport/resource_pureport_site_vpn_connection.go
+++ b/pureport/resource_pureport_site_vpn_connection.go
@@ -135,12 +135,12 @@ func resourceSiteVPNConnection() *schema.Resource {
 					"customer_side": {
 						Type:         schema.TypeString,
 						Required:     true,
-						ValidateFunc: validation.CIDRNetwork(16, 32),
+						ValidateFunc: validation.CIDRNetwork(8, 32),
 					},
 					"pureport_side": {
 						Type:         schema.TypeString,
 						Required:     true,
-						ValidateFunc: validation.CIDRNetwork(16, 32),
+						ValidateFunc: validation.CIDRNetwork(8, 32),
 					},
 				},
 			},


### PR DESCRIPTION
 The Pureport Console allows CIDRs between 8 and 32.