### PR TITLE
Validate that AWS Cloud Service prefixes are within a valid range

### DIFF
--- a/pureport/data_source_pureport_cloud_services_test.go
+++ b/pureport/data_source_pureport_cloud_services_test.go
@@ -2,6 +2,7 @@ package pureport
 
 import (
 	"fmt"
+	"regexp"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
@@ -42,8 +43,8 @@ func TestDataSourceCloudServicesDataSource_empty(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "services.0.name", "AWS Dynamodb us-east-1"),
 					resource.TestCheckResourceAttr(resourceName, "services.0.provider", "AWS"),
 					resource.TestCheckResourceAttr(resourceName, "services.0.service", "DYNAMODB"),
-					resource.TestCheckResourceAttr(resourceName, "services.0.ipv4_prefix_count", "5"),
-					resource.TestCheckResourceAttr(resourceName, "services.0.ipv6_prefix_count", "0"),
+					resource.TestMatchResourceAttr(resourceName, "services.0.ipv4_prefix_count", regexp.MustCompile("[0-9]{1,2}")),
+					resource.TestMatchResourceAttr(resourceName, "services.0.ipv6_prefix_count", regexp.MustCompile("[0-9]{1,2}")),
 					resource.TestCheckResourceAttr(resourceName, "services.0.cloud_region_id", "aws-us-east-1"),
 
 					resource.TestCheckResourceAttr(resourceName, "services.4.id", "aws-s3-us-east-1"),
@@ -51,8 +52,8 @@ func TestDataSourceCloudServicesDataSource_empty(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "services.4.name", "AWS S3 us-east-1"),
 					resource.TestCheckResourceAttr(resourceName, "services.4.provider", "AWS"),
 					resource.TestCheckResourceAttr(resourceName, "services.4.service", "S3"),
-					resource.TestCheckResourceAttr(resourceName, "services.4.ipv4_prefix_count", "5"),
-					resource.TestCheckResourceAttr(resourceName, "services.4.ipv6_prefix_count", "4"),
+					resource.TestMatchResourceAttr(resourceName, "services.0.ipv4_prefix_count", regexp.MustCompile("[0-9]{1,2}")),
+					resource.TestMatchResourceAttr(resourceName, "services.0.ipv6_prefix_count", regexp.MustCompile("[0-9]{1,2}")),
 					resource.TestCheckResourceAttr(resourceName, "services.4.cloud_region_id", "aws-us-east-1"),
 				),
 			},
@@ -80,8 +81,8 @@ func TestDataSourceCloudServicesDataSource_name_filter(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "services.0.name", "AWS S3 us-west-2"),
 					resource.TestCheckResourceAttr(resourceName, "services.0.provider", "AWS"),
 					resource.TestCheckResourceAttr(resourceName, "services.0.service", "S3"),
-					resource.TestCheckResourceAttr(resourceName, "services.0.ipv4_prefix_count", "5"),
-					resource.TestCheckResourceAttr(resourceName, "services.0.ipv6_prefix_count", "4"),
+					resource.TestMatchResourceAttr(resourceName, "services.0.ipv4_prefix_count", regexp.MustCompile("[0-9]{1,2}")),
+					resource.TestMatchResourceAttr(resourceName, "services.0.ipv6_prefix_count", regexp.MustCompile("[0-9]{1,2}")),
 					resource.TestCheckResourceAttr(resourceName, "services.0.cloud_region_id", "aws-us-west-2"),
 				),
 			},


### PR DESCRIPTION
Now we just make sure it's within 0-99.