### PR TITLE
[PE-2149] Add custom validator for cloud connections for HA

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,6 +97,11 @@ In order to run the full suite of Acceptance tests, run `make testacc`.
 $ make testacc
 ```
 
+If you want to run just a specific test in the acceptance test suite, override the TESTARGS paramter
+```sh
+$ make testacc TESTARGS='-run=TestResourceAWSConnection_basic'
+```
+
 You can also install the plugin which will build and copy the plugin to your terraform third party
 plugin directory. You'll need to re-initialize terraform in module directory after installing the
 new plugin.

--- a/pureport/connection/connection.go
+++ b/pureport/connection/connection.go
@@ -706,7 +706,7 @@ func CloudResourceDiff(d *schema.ResourceDiff) error {
 	}
 
 	if !highAvailability && speed > 50 {
-		return fmt.Errorf("Cloud Connection with high availability required for for speeds greater than 50Mbps")
+		return fmt.Errorf("Cloud Connection with high availability required for speeds greater than 50Mbps")
 	}
 
 	return nil

--- a/pureport/connection/connection.go
+++ b/pureport/connection/connection.go
@@ -696,3 +696,18 @@ func ExpandPeeringType(d *schema.ResourceData) *client.PeeringConfiguration {
 
 	return peeringConfig
 }
+
+func CloudResourceDiff(d *schema.ResourceDiff) error {
+	speed := d.Get("speed").(int)
+
+	highAvailability := false
+	if v, ok := d.GetOk("high_availability"); ok {
+		highAvailability = v.(bool)
+	}
+
+	if !highAvailability && speed > 50 {
+		return fmt.Errorf("Cloud Connection with high availability required for for speeds greater than 50Mbps")
+	}
+
+	return nil
+}

--- a/pureport/resource_pureport_aws_connection.go
+++ b/pureport/resource_pureport_aws_connection.go
@@ -8,6 +8,7 @@ import (
 	"sort"
 
 	"github.com/antihax/optional"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/customdiff"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/structure"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/validation"
@@ -77,6 +78,14 @@ func resourceAWSConnection() *schema.Resource {
 			Create: schema.DefaultTimeout(connection.CreateTimeout),
 			Delete: schema.DefaultTimeout(connection.DeleteTimeout),
 		},
+		CustomizeDiff: customdiff.If(
+			customdiff.ResourceConditionFunc(func(d *schema.ResourceDiff, meta interface{}) bool {
+				return d.HasChange("speed") || d.HasChange("high_availability")
+			}),
+			schema.CustomizeDiffFunc(func(d *schema.ResourceDiff, meta interface{}) error {
+				return connection.CloudResourceDiff(d)
+			}),
+		),
 	}
 }
 

--- a/pureport/resource_pureport_aws_connection_test.go
+++ b/pureport/resource_pureport_aws_connection_test.go
@@ -515,7 +515,7 @@ func TestResourceAWSConnection_invalid_ha(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config:      testAccResourceAWSConnectionConfig_invalid_ha(),
-				ExpectError: regexp.MustCompile("Cloud Connection with high availability required for for speeds greater than 50Mbps"),
+				ExpectError: regexp.MustCompile("Cloud Connection with high availability required for speeds greater than 50Mbps"),
 			},
 		},
 	})

--- a/pureport/resource_pureport_aws_connection_test.go
+++ b/pureport/resource_pureport_aws_connection_test.go
@@ -264,6 +264,32 @@ resource "pureport_aws_connection" "nat_mapping" {
 	return fmt.Sprintf(format, connection_name)
 }
 
+func testAccResourceAWSConnectionConfig_invalid_ha() string {
+	format := `
+resource "pureport_aws_connection" "basic" {
+  name = "%s"
+  speed = "100"
+  high_availability = false
+
+  location_href = "location/blah"
+  network_href = "network/blah"
+
+  aws_region = "us-east"
+  aws_account_id = "some-id"
+
+  tags = {
+    Environment = "tf-test"
+    Owner       = "ksk-aws"
+    sweep       = "TRUE"
+  }
+}
+`
+
+	connection_name := acctest.RandomWithPrefix("AwsDirectConnectTest")
+
+	return fmt.Sprintf(format, connection_name)
+}
+
 func TestResourceAWSConnection_basic(t *testing.T) {
 
 	resourceName := "pureport_aws_connection.basic"
@@ -476,6 +502,20 @@ func TestResourceAWSConnection_nat_mappings(t *testing.T) {
 						//					resource.TestCheckResourceAttrSet(resourceName, "nat_config.0.mappings.1.nat_cidr"),
 					),
 				),
+			},
+		},
+	})
+}
+
+func TestResourceAWSConnection_invalid_ha(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		IsUnitTest: true,
+		PreCheck:   func() { testAccPreCheck(t) },
+		Providers:  testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config:      testAccResourceAWSConnectionConfig_invalid_ha(),
+				ExpectError: regexp.MustCompile("Cloud Connection with high availability required for for speeds greater than 50Mbps"),
 			},
 		},
 	})

--- a/pureport/resource_pureport_azure_connection.go
+++ b/pureport/resource_pureport_azure_connection.go
@@ -7,6 +7,7 @@ import (
 	"path/filepath"
 
 	"github.com/antihax/optional"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/customdiff"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/structure"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/validation"
@@ -66,6 +67,14 @@ func resourceAzureConnection() *schema.Resource {
 			Create: schema.DefaultTimeout(connection.CreateTimeout),
 			Delete: schema.DefaultTimeout(connection.DeleteTimeout),
 		},
+		CustomizeDiff: customdiff.If(
+			customdiff.ResourceConditionFunc(func(d *schema.ResourceDiff, meta interface{}) bool {
+				return d.HasChange("speed") || d.HasChange("high_availability")
+			}),
+			schema.CustomizeDiffFunc(func(d *schema.ResourceDiff, meta interface{}) error {
+				return connection.CloudResourceDiff(d)
+			}),
+		),
 	}
 }
 

--- a/pureport/resource_pureport_azure_connection_test.go
+++ b/pureport/resource_pureport_azure_connection_test.go
@@ -100,6 +100,32 @@ resource "pureport_azure_connection" "main" {
 	return fmt.Sprintf(format, connection_name)
 }
 
+func testAccResourceAzureConnectionConfig_invalid_ha() string {
+	format := `
+resource "pureport_azure_connection" "main" {
+  name = "%s"
+  description = "Some random description"
+  speed = "100"
+  high_availability = false
+
+  location_href = "location/blah"
+  network_href = "network/blah"
+
+  service_key = "some-key"
+
+  tags = {
+    Environment = "tf-test"
+    Owner       = "ksk-azure"
+    sweep       = "TRUE"
+  }
+}
+`
+
+	connection_name := acctest.RandomWithPrefix("AzureExpressRouteTest")
+
+	return fmt.Sprintf(format, connection_name)
+}
+
 func TestResourceAzureConnection_basic(t *testing.T) {
 
 	resourceName := "pureport_azure_connection.main"
@@ -155,6 +181,21 @@ func TestResourceAzureConnection_basic(t *testing.T) {
 						resource.TestCheckResourceAttr(resourceName, "tags.Owner", "ksk-azure"),
 					),
 				),
+			},
+		},
+	})
+}
+
+func TestResourceAzureConnection_invalid_ha(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		IsUnitTest:   true,
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSConnectionDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config:      testAccResourceAzureConnectionConfig_invalid_ha(),
+				ExpectError: regexp.MustCompile("Cloud Connection with high availability required for for speeds greater than 50Mbps"),
 			},
 		},
 	})

--- a/pureport/resource_pureport_azure_connection_test.go
+++ b/pureport/resource_pureport_azure_connection_test.go
@@ -195,7 +195,7 @@ func TestResourceAzureConnection_invalid_ha(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config:      testAccResourceAzureConnectionConfig_invalid_ha(),
-				ExpectError: regexp.MustCompile("Cloud Connection with high availability required for for speeds greater than 50Mbps"),
+				ExpectError: regexp.MustCompile("Cloud Connection with high availability required for speeds greater than 50Mbps"),
 			},
 		},
 	})

--- a/pureport/resource_pureport_google_cloud_connection.go
+++ b/pureport/resource_pureport_google_cloud_connection.go
@@ -7,6 +7,7 @@ import (
 	"path/filepath"
 
 	"github.com/antihax/optional"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/customdiff"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/structure"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/validation"
@@ -63,6 +64,14 @@ func resourceGoogleCloudConnection() *schema.Resource {
 			Create: schema.DefaultTimeout(connection.CreateTimeout),
 			Delete: schema.DefaultTimeout(connection.DeleteTimeout),
 		},
+		CustomizeDiff: customdiff.If(
+			customdiff.ResourceConditionFunc(func(d *schema.ResourceDiff, meta interface{}) bool {
+				return d.HasChange("speed") || d.HasChange("high_availability")
+			}),
+			schema.CustomizeDiffFunc(func(d *schema.ResourceDiff, meta interface{}) error {
+				return connection.CloudResourceDiff(d)
+			}),
+		),
 	}
 }
 

--- a/pureport/resource_pureport_google_cloud_connection_test.go
+++ b/pureport/resource_pureport_google_cloud_connection_test.go
@@ -119,6 +119,31 @@ resource "pureport_google_cloud_connection" "main" {
 	return fmt.Sprintf(format, environment_name, router_name, interconnect_name, connection_name)
 }
 
+func testAccResourceGoogleCloudConnectionConfig_invalid_ha() string {
+	format := `
+resource "pureport_google_cloud_connection" "main" {
+  name = "%s"
+  speed = "100"
+  high_availability = false
+
+  location_href = "location/blah"
+  network_href = "network/blah"
+
+  primary_pairing_key = "some-key"
+
+  tags = {
+    Environment = "tf-test"
+    Owner       = "ksk-google"
+    sweep       = "TRUE"
+  }
+}
+`
+
+	connection_name := acctest.RandomWithPrefix("GoogleCloudTest")
+
+	return fmt.Sprintf(format, connection_name)
+}
+
 func TestResourceGoogleCloudConnection_basic(t *testing.T) {
 
 	resourceName := "pureport_google_cloud_connection.main"
@@ -158,6 +183,21 @@ func TestResourceGoogleCloudConnection_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "tags.Environment", "tf-test"),
 					resource.TestCheckResourceAttr(resourceName, "tags.Owner", "ksk-google"),
 				),
+			},
+		},
+	})
+}
+
+func TestResourceGoogleCloudConnection_invalid_ha(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		IsUnitTest:   true,
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSConnectionDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config:      testAccResourceGoogleCloudConnectionConfig_invalid_ha(),
+				ExpectError: regexp.MustCompile("Cloud Connection with high availability required for for speeds greater than 50Mbps"),
 			},
 		},
 	})

--- a/pureport/resource_pureport_google_cloud_connection_test.go
+++ b/pureport/resource_pureport_google_cloud_connection_test.go
@@ -197,7 +197,7 @@ func TestResourceGoogleCloudConnection_invalid_ha(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config:      testAccResourceGoogleCloudConnectionConfig_invalid_ha(),
-				ExpectError: regexp.MustCompile("Cloud Connection with high availability required for for speeds greater than 50Mbps"),
+				ExpectError: regexp.MustCompile("Cloud Connection with high availability required for speeds greater than 50Mbps"),
 			},
 		},
 	})


### PR DESCRIPTION
```release-note:improvements
Since Cloud Connections only provided Non-HA connections for 50Mbps, add a custom
resource validator to enforce this. Also added Unit Tests to test for this.
```