### PR TITLE
[PE-2173] consistent parameters across providers

### DIFF
--- a/pureport/resource_pureport_site_vpn_connection.go
+++ b/pureport/resource_pureport_site_vpn_connection.go
@@ -27,7 +27,8 @@ func resourceSiteVPNConnection() *schema.Resource {
 		},
 		"ike_version": {
 			Type:         schema.TypeString,
-			Required:     true,
+			Optional:     true,
+			Computed:     true,
 			ValidateFunc: validation.StringInSlice([]string{"V1", "V2"}, true),
 			StateFunc: func(val interface{}) string {
 				return strings.ToUpper(val.(string))
@@ -295,6 +296,10 @@ func expandSiteVPNConnection(d *schema.ResourceData) client.SiteIpSecVpnConnecti
 
 	// Generic Connection values
 	speed := d.Get("speed").(int)
+	ikeVersion := "V2"
+	if version, ok := d.GetOk("ike_version"); ok {
+		ikeVersion = version.(string)
+	}
 
 	// Create the body of the request
 	c := client.SiteIpSecVpnConnection{
@@ -302,7 +307,7 @@ func expandSiteVPNConnection(d *schema.ResourceData) client.SiteIpSecVpnConnecti
 		Name:        d.Get("name").(string),
 		Speed:       int32(speed),
 		AuthType:    d.Get("auth_type").(string),
-		IkeVersion:  d.Get("ike_version").(string),
+		IkeVersion:  ikeVersion,
 		RoutingType: d.Get("routing_type").(string),
 		PrimaryKey:  d.Get("primary_key").(string),
 

--- a/pureport/resource_pureport_site_vpn_connection_test.go
+++ b/pureport/resource_pureport_site_vpn_connection_test.go
@@ -70,8 +70,6 @@ resource "pureport_site_vpn_connection" "main" {
   location_href = data.pureport_locations.main.locations.0.href
   network_href = data.pureport_networks.main.networks.0.href
 
-  ike_version = "V2"
-
   routing_type = "ROUTE_BASED_BGP"
   customer_asn = 30000
 


### PR DESCRIPTION
Change IKE version to Optional and default to V2 to align with
Kato default.

**Jira Issue**: [PE-2173]

<!---
Include a brief summary of the change

Available Release note types:

* release-note:bug
* release-note:features
* release-note:enhancement
* release-note:breakingchange
--->

```release-note:enhancement
Set the default IKE Version to 'V2'.
```

## Details

To align with the control plane default, set the IKE version default to "V2" for SiteVPN connections.


[PE-2173]: https://pureport.atlassian.net/browse/PE-2173