### PR TITLE
[PE-2173] Update documentation to show ike_version as optional

### DIFF
--- a/website/docs/r/site_vpn_connection.html.md
+++ b/website/docs/r/site_vpn_connection.html.md
@@ -41,8 +41,6 @@ resource "pureport_site_vpn_connection" "main" {
   location_href = data.pureport_locations.main.locations.0.href
   network_href = data.pureport_networks.main.networks.0.href
 
-  ike_version = "V2"
-
   routing_type = "ROUTE_BASED_BGP"
   customer_asn = 30000
 
@@ -62,7 +60,7 @@ The following arguments are supported:
 
 * `auth_type` - (Optional) The Authentication Type to use. (Currently only `PSK` is supported.)
 * `enable_bgp_password` - (Optional) Enable BGP password authentication. (Default:  false)
-* `ike_version` - (Required) the IKE Version to use. Valid values are `V1`, `V2`.
+* `ike_version` - (Optional) the IKE Version to use. Valid values are `V1`, `V2` (default = `V2`).
 
 * `ike_config` - (Optional) IKE Configuration to use:
     * `esp` - Encapsulating Security Payload


### PR DESCRIPTION
Update the documentation to show that IKE Version is optional and
defaults to `V2`.

**Jira Issue**: [PE-2173]

```release-note
Make IKE version optional. Defaults to V2
```

[PE-2173]: https://pureport.atlassian.net/browse/PE-2173