### PR TITLE
[PE-2210] Set a valid default value for Oracle OCID

### DIFF
--- a/pureport/provider_test.go
+++ b/pureport/provider_test.go
@@ -16,8 +16,8 @@ var (
 	testAccProvider  *schema.Provider
 
 	testEnvironmentName     string = "Production"
-	testOraclePrimaryOCID   string = ""
-	testOracleSecondaryOCID string = ""
+	testOraclePrimaryOCID   string = "ocid1.instance.oc1.phx.abuw4ljrlsfiqw6vzzxb4300000000000000000000000000000000000001"
+	testOracleSecondaryOCID string = "ocid1.instance.oc1.phx.abuw4ljrlsfiqw6vzzxb4300000000000000000000000000000000000002"
 )
 
 func init() {


### PR DESCRIPTION
**Jira Issue**: [PE-2210]

## Details

<!--- Add any detailed information here -->
Add default value for Oracle OCID.
This is needed for the Oracle acceptance tests.

[PE-2210]: https://pureport.atlassian.net/browse/PE-2210