### PR TITLE
[PE-2257] Recreate connection on network update

### DIFF
--- a/pureport/connection/connection.go
+++ b/pureport/connection/connection.go
@@ -188,6 +188,7 @@ func GetBaseResourceConnectionSchema() map[string]*schema.Schema {
 		"network_href": {
 			Type:     schema.TypeString,
 			Required: true,
+			ForceNew: true,
 		},
 		"description": {
 			Type:     schema.TypeString,

--- a/pureport/resource_pureport_network.go
+++ b/pureport/resource_pureport_network.go
@@ -29,6 +29,7 @@ func resourceNetwork() *schema.Resource {
 			"account_href": {
 				Type:     schema.TypeString,
 				Required: true,
+				ForceNew: true,
 			},
 			"description": {
 				Type:     schema.TypeString,


### PR DESCRIPTION

**Jira Issue**: [PE-2257]

```release-note:
Recreate Connections on network changes.
Recreate Networks on account changes.
```

## Details

<!--- Add any detailed information here -->
Currently when changing the network for a connection, Terraform says it's
being applied but nothing changes.

Now we add the `ForceNew` parameter to force delete/create for the resource.

Also needed to add this for account changes on Network resources.


[PE-2257]: https://pureport.atlassian.net/browse/PE-2257