### PR TITLE
Update example for cloud regions data source

### DIFF
--- a/website/docs/d/cloud_regions.html.md
+++ b/website/docs/d/cloud_regions.html.md
@@ -13,7 +13,7 @@ description: |-
 ```hcl
 data "pureport_cloud_regions" "name_regex" {
   filter {
-    name = "Name"
+    name = "DisplayName"
     values = ["US East.*"]
   }
 }


### PR DESCRIPTION
Fixes #54

Update the filter name in the example for the could regions data
source to match the new data model listed in the Purepork SDK.

* Update website doc for cloud region data source
